### PR TITLE
Include a metadata defs file in settings package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.3.0] - 2016-10-06
+### Added
+- Include a metadata.json file in settings package that defines the user's
+  dataset preference for synchronization.
+
 ## [2.2.0] - 2016-10-06
 ### Added
 - Include a layers.json file in settings package that defines layers for vector tiles.

--- a/bin/mapeo-settings-builder.js
+++ b/bin/mapeo-settings-builder.js
@@ -35,6 +35,7 @@ var iconDir = path.join(cwd, 'icons')
 var imageryFile = path.join(cwd, 'imagery.json')
 var styleFile = path.join(cwd, 'style.css')
 var layersFile = path.join(cwd, 'layers.json')
+var metadataFile = path.join(cwd, 'metadata.json')
 
 var opts = {
   additionalProperties: true
@@ -90,6 +91,9 @@ run([
   }
   if (exists(layersFile)) {
     pack.entry({ name: 'layers.json' }, fs.readFileSync(layersFile))
+  }
+  if (exists(metadataFile)) {
+    pack.entry({ name: 'metadata.json' }, fs.readFileSync(metadataFile))
   }
   pack.finalize()
   var outputStream = argv.o ? fs.createWriteStream(argv.o) : process.stdout


### PR DESCRIPTION
This is for declaring a dataset_id for controlled dataset synchronization.