### PR TITLE
Add syncServer parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Where:
   - `projectKey` is a 32 byte (256-bit) random number encoded as a `hex` string (numbers 0-9 and lowercase letters a-f)
   - `name` is a human-readable name of these presets (written from `package.json` if it does not already exist)
   - `version` is the version number of the presets (written from `package.json` if it does not already exist)
+  - `syncServer` is the URL of a mapeo-web server to sync to. (written from `package.json` if it does not already exist)
 
 ### Options
 

--- a/commands/build_lint.js
+++ b/commands/build_lint.js
@@ -142,6 +142,7 @@ module.exports = function ({ output, lang }, sourceDir, { lint } = { lint: false
       }
       metadata.name = metadata.name || pak.name
       metadata.version = metadata.version || pak.version
+      metadata.syncServer = metadata.syncServer || pak.syncServer
       pack.entry({ name: 'metadata.json' }, stringify(metadata))
       if (pngIcons) {
         pngIcons.forEach(icon => {

--- a/commands/build_lint.js
+++ b/commands/build_lint.js
@@ -142,7 +142,23 @@ module.exports = function ({ output, lang }, sourceDir, { lint } = { lint: false
       }
       metadata.name = metadata.name || pak.name
       metadata.version = metadata.version || pak.version
-      metadata.syncServer = metadata.syncServer || pak.syncServer
+
+      if (metadata.syncServer) {
+        try {
+          const parsed = new URL(metadata.syncServer)
+          if (parsed.protocol !== 'wss') {
+            if (parsed.protocol !== 'ws') {
+              log.error(`Error: syncServer was set to an invalid protocol: ${parsed.protocol}`)
+              return
+            } else {
+              log.warn('syncServer protocol got set to `ws`, did you mean to use `wss` for a secure connection?')
+            }
+          }
+        } catch (e) {
+          log.error('Error parsing syncServer:', e.message)
+        }
+      }
+
       pack.entry({ name: 'metadata.json' }, stringify(metadata))
       if (pngIcons) {
         pngIcons.forEach(icon => {


### PR DESCRIPTION
This parameter will be used in mapeo-desktop and mapeo-web to sync with mapeo-web instances.

It must be a `ws://` or `ws://` URL.

In the future we could have other schemes like `tcp://` `utp://` or `i2p://`.

In the future we might want to have this be an array of sync servers.