### PR TITLE
feat: Add timeout CLI flag for icon generation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Where:
 
 - `-l, --lang=<langCode>` - the base language of the settings, defaults to `en`.
 - `-o, --output=<filename>` - write the settings tarball to this file, if unspecified prints to stdout.
+- `-t, --timeout=<number>` - timeout limit (in milliseconds) for icon generation process.
 
 ## Contribute
 

--- a/bin/mapeo-settings-builder.js
+++ b/bin/mapeo-settings-builder.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 var updateNotifier = require('update-notifier')
-var commander, { program } = require('commander')
+var { program, CommanderError } = require('commander')
 var { randomBytes } = require('crypto')
 var pkg = require('../package.json')
 var log = require('../scripts/log')
@@ -44,13 +44,13 @@ program
   .description('Build config from presets in current working dir')
   .option('-o, --output <file>', 'Output file (defaults to stdout)')
   .option('-l, --lang <language-code>', 'Default language of presets', 'en')
-  .option('-t, --timeout <milliseconds>', 'Timeout limit for icon generation process', function(value) {
+  .option('-t, --timeout <number>', 'Timeout limit (in milliseconds) for icon generation process', function(value) {
     const parsedValue = parseInt(value, 10);
     if (isNaN(parsedValue)) {
-      return 2000
+      throw new CommanderError(1, 'commander.invalidArgument', `Value "${value}" is not a number`)
     }
     return parsedValue;
-  })
+  }, 2000)
   .action((sourceDir, opts) => {
     buildLint(opts, sourceDir || cwd)
   })

--- a/bin/mapeo-settings-builder.js
+++ b/bin/mapeo-settings-builder.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 var updateNotifier = require('update-notifier')
-var { program } = require('commander')
+var commander, { program } = require('commander')
 var { randomBytes } = require('crypto')
 var pkg = require('../package.json')
 var log = require('../scripts/log')
@@ -44,7 +44,13 @@ program
   .description('Build config from presets in current working dir')
   .option('-o, --output <file>', 'Output file (defaults to stdout)')
   .option('-l, --lang <language-code>', 'Default language of presets', 'en')
-  .option('-t, --timeout <milliseconds>', 'Timeout limit for icon generation process', 2000)
+  .option('-t, --timeout <milliseconds>', 'Timeout limit for icon generation process', function(value) {
+    const parsedValue = parseInt(value, 10);
+    if (isNaN(parsedValue)) {
+      return 2000
+    }
+    return parsedValue;
+  })
   .action((sourceDir, opts) => {
     buildLint(opts, sourceDir || cwd)
   })

--- a/bin/mapeo-settings-builder.js
+++ b/bin/mapeo-settings-builder.js
@@ -44,6 +44,7 @@ program
   .description('Build config from presets in current working dir')
   .option('-o, --output <file>', 'Output file (defaults to stdout)')
   .option('-l, --lang <language-code>', 'Default language of presets', 'en')
+  .option('-t, --timeout <milliseconds>', 'Timeout limit for icon generation process', 2000)
   .action((sourceDir, opts) => {
     buildLint(opts, sourceDir || cwd)
   })

--- a/commands/build_lint.js
+++ b/commands/build_lint.js
@@ -16,7 +16,7 @@ var checkIcons = require('../scripts/check_icons')
 var pkg = require('../package.json')
 var log = require('../scripts/log')
 
-module.exports = function ({ output, lang }, sourceDir, { lint } = { lint: false }) {
+module.exports = function ({ output, lang, timeout }, sourceDir, { lint } = { lint: false }) {
   var iconDir = path.join(sourceDir, 'icons')
   var messagesDir = path.join(sourceDir, 'messages')
   var imageryFile = path.join(sourceDir, 'imagery.json')
@@ -52,7 +52,7 @@ module.exports = function ({ output, lang }, sourceDir, { lint } = { lint: false
       ),
       wrapWithLog(
         'Generated png icons for Mapeo Mobile',
-        buildPNGIcons.bind(null, iconDir)
+        buildPNGIcons.bind(null, iconDir, timeout)
       ),
       wrapWithLog(
         'Generated translations',

--- a/package-lock.json
+++ b/package-lock.json
@@ -2463,6 +2463,11 @@
         "p-is-promise": "^2.0.0"
       }
     },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+    },
     "mime-db": {
       "version": "1.42.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
@@ -3203,9 +3208,9 @@
       }
     },
     "proxy-from-env": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
-      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "psl": {
       "version": "1.4.0",
@@ -3232,6 +3237,36 @@
       "integrity": "sha512-hEJH0s8PXLY/cdXh66tNEQGndDrIKNqNC5xmrysZy3i5C3oEoLna7YAOad+7u125+zH1HNXUmGEkrhb3c2VriA==",
       "requires": {
         "escape-goat": "^2.0.0"
+      }
+    },
+    "puppeteer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.1.1.tgz",
+      "integrity": "sha1-rb8l5J9e8DRDwQq44JqVTKDHv+4=",
+      "requires": {
+        "debug": "^2.6.8",
+        "extract-zip": "^1.6.5",
+        "https-proxy-agent": "^2.1.0",
+        "mime": "^1.3.4",
+        "progress": "^2.0.0",
+        "proxy-from-env": "^1.0.0",
+        "rimraf": "^2.6.1",
+        "ws": "^3.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "q": {
@@ -3844,56 +3879,10 @@
       }
     },
     "svg-to-img": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/svg-to-img/-/svg-to-img-2.0.9.tgz",
-      "integrity": "sha512-FPQc7gPJq54d7cjD4vDahaXMIpZv4bk1AJOMuRtqylwdaszaAIFqgTLuP3lZFDGydAPW2okFzf3ZrwuOyRxNvw==",
+      "version": "github:digidem/svg-to-img#90b2cca384dfb5a6963fe815b9f3713bf8c6f979",
+      "from": "github:digidem/svg-to-img#90b2cca",
       "requires": {
         "puppeteer": "1.1.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "mime": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "puppeteer": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.1.1.tgz",
-          "integrity": "sha1-rb8l5J9e8DRDwQq44JqVTKDHv+4=",
-          "requires": {
-            "debug": "^2.6.8",
-            "extract-zip": "^1.6.5",
-            "https-proxy-agent": "^2.1.0",
-            "mime": "^1.3.4",
-            "progress": "^2.0.0",
-            "proxy-from-env": "^1.0.0",
-            "rimraf": "^2.6.1",
-            "ws": "^3.0.0"
-          }
-        },
-        "ws": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
-          "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0",
-            "ultron": "~1.1.0"
-          }
-        }
       }
     },
     "svgo": {
@@ -4433,6 +4422,16 @@
         "is-typedarray": "^1.0.0",
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "ws": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+      "requires": {
+        "async-limiter": "~1.0.0",
+        "safe-buffer": "~5.1.0",
+        "ultron": "~1.1.0"
       }
     },
     "xdg-basedir": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,14 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@digidem/svg-to-img": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@digidem/svg-to-img/-/svg-to-img-2.1.0.tgz",
+      "integrity": "sha512-5g3ln2sjcsjl/lr90qGP1AIfKV+Y45AN7zGcVepIYMneDqOvPozUt667nSDI9ayIupdYUaGQm7OX44NIplXv3A==",
+      "requires": {
+        "puppeteer": "1.1.1"
+      }
+    },
     "@mapbox/shelf-pack": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@mapbox/shelf-pack/-/shelf-pack-3.0.0.tgz",
@@ -3876,13 +3884,6 @@
         "xmldom": "0.1.27",
         "xpath": "^0.0.27",
         "yargs": "^12.0.2"
-      }
-    },
-    "svg-to-img": {
-      "version": "github:digidem/svg-to-img#90b2cca384dfb5a6963fe815b9f3713bf8c6f979",
-      "from": "github:digidem/svg-to-img#90b2cca",
-      "requires": {
-        "puppeteer": "1.1.1"
       }
     },
     "svgo": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "run-series": "^1.1.8",
     "safe-stable-stringify": "^1.1.1",
     "svg-sprite": "^1.5.0",
-    "svg-to-img": "^2.0.9",
+    "svg-to-img": "digidem/svg-to-img.git#90b2cca",
     "tar-stream": "^2.1.3",
     "traverse": "^0.6.6",
     "update-notifier": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "run-series": "^1.1.8",
     "safe-stable-stringify": "^1.1.1",
     "svg-sprite": "^1.5.0",
-    "svg-to-img": "digidem/svg-to-img.git#90b2cca",
+    "@digidem/svg-to-img": "^2.1.0",
     "tar-stream": "^2.1.3",
     "traverse": "^0.6.6",
     "update-notifier": "^4.1.1",

--- a/scripts/build_png_icons.js
+++ b/scripts/build_png_icons.js
@@ -20,7 +20,7 @@ Object.keys(SIZES).forEach(size =>
   SCALES.forEach(scale => outputs.push({ size, scale }))
 )
 
-module.exports = function buildPngIcons (dir, timeout = 2000, cb) {
+module.exports = function buildPngIcons (dir, timeout, cb) {
   const svgFiles = glob.sync('*-100px.svg', { cwd: dir })
   if (!svgFiles || svgFiles.length === 0) return cb(null, {})
 

--- a/scripts/build_png_icons.js
+++ b/scripts/build_png_icons.js
@@ -35,7 +35,7 @@ module.exports = function buildPngIcons (dir, cb) {
           var png = await svgToImg.from(resizedSvg).toPng({
             width: SIZES[size] * scale,
             height: SIZES[size] * scale,
-            destroyBrowserTimeout: 1500
+            destroyBrowserTimeout: timeout || 2000
           })
           var filename = `${id}-${size}@${scale}x.png`
           return { png, filename }

--- a/scripts/build_png_icons.js
+++ b/scripts/build_png_icons.js
@@ -1,7 +1,7 @@
 var fs = require('fs')
 var glob = require('glob')
 var path = require('path')
-var svgToImg = require('svg-to-img')
+var svgToImg = require('@digidem/svg-to-img')
 var { promisify } = require('util')
 
 var readFile = promisify(fs.readFile)

--- a/scripts/build_png_icons.js
+++ b/scripts/build_png_icons.js
@@ -20,7 +20,7 @@ Object.keys(SIZES).forEach(size =>
   SCALES.forEach(scale => outputs.push({ size, scale }))
 )
 
-module.exports = function buildPngIcons (dir, cb) {
+module.exports = function buildPngIcons (dir, timeout, cb) {
   const svgFiles = glob.sync('*-100px.svg', { cwd: dir })
   if (!svgFiles || svgFiles.length === 0) return cb(null, {})
 

--- a/scripts/build_png_icons.js
+++ b/scripts/build_png_icons.js
@@ -20,7 +20,7 @@ Object.keys(SIZES).forEach(size =>
   SCALES.forEach(scale => outputs.push({ size, scale }))
 )
 
-module.exports = function buildPngIcons (dir, timeout, cb) {
+module.exports = function buildPngIcons (dir, timeout = 2000, cb) {
   const svgFiles = glob.sync('*-100px.svg', { cwd: dir })
   if (!svgFiles || svgFiles.length === 0) return cb(null, {})
 
@@ -35,7 +35,7 @@ module.exports = function buildPngIcons (dir, timeout, cb) {
           var png = await svgToImg.from(resizedSvg).toPng({
             width: SIZES[size] * scale,
             height: SIZES[size] * scale,
-            destroyBrowserTimeout: timeout || 2000
+            destroyBrowserTimeout: timeout
           })
           var filename = `${id}-${size}@${scale}x.png`
           return { png, filename }

--- a/scripts/build_png_icons.js
+++ b/scripts/build_png_icons.js
@@ -34,7 +34,8 @@ module.exports = function buildPngIcons (dir, cb) {
         outputs.map(async ({ size, scale }) => {
           var png = await svgToImg.from(resizedSvg).toPng({
             width: SIZES[size] * scale,
-            height: SIZES[size] * scale
+            height: SIZES[size] * scale,
+            destroyBrowserTimeout: 1500
           })
           var filename = `${id}-${size}@${scale}x.png`
           return { png, filename }


### PR DESCRIPTION
Closes #30 

Note:
- I forked `svg-to-img` to [our org](https://github.com/digidem/svg-to-img/) and published a namespaced version of the dep `@digidem/svg-to-img` that allows a custom value to be provided for scheduling the browser destruction.
- Updates the CLI so to allow the end-user to provide a `--timeout` (or `-t`) flag to specify the browser destruction timeout value in milliseconds. Default value is 2000 ms