### PR TITLE
fix: Also notify of major updates

### DIFF
--- a/bin/mapeo-settings-builder.js
+++ b/bin/mapeo-settings-builder.js
@@ -16,7 +16,7 @@ const notifier = updateNotifier({
   shouldNotifyInNpmScript: true
 })
 
-if (notifier.update && notifier.update.type !== 'major') {
+if (notifier.update) {
   notifier.notify({
     message: `Update of ${pkg.name} available!
 ${chalk.red('v{currentVersion}')} → ${chalk.green('v{latestVersion}')}


### PR DESCRIPTION
When there is a major update of mapeo-settings-builder, we should also notify of the update.