### PR TITLE
feat: add additional metadata

### DIFF
--- a/commands/build_lint.js
+++ b/commands/build_lint.js
@@ -14,6 +14,8 @@ import buildTranslations from '../scripts/build_translations.js'
 import checkIcons from '../scripts/check_icons.js'
 import log from '../scripts/log.js'
 
+const CONFIG_FILE_VERSION = 1
+
 const pkg = JSON.parse(
   fs.readFileSync(
     new URL('../package.json', import.meta.url)
@@ -161,6 +163,8 @@ export default function buildLint({ output, lang, timeout }, sourceDir, { lint }
       }
       metadata.name = metadata.name || pak.name
       metadata.version = metadata.version || pak.version
+      metadata.fileVersion = CONFIG_FILE_VERSION
+      metadata.buildDate = new Date().toISOString()
 
       if (metadata.syncServer) {
         try {

--- a/commands/build_lint.js
+++ b/commands/build_lint.js
@@ -14,7 +14,7 @@ import buildTranslations from '../scripts/build_translations.js'
 import checkIcons from '../scripts/check_icons.js'
 import log from '../scripts/log.js'
 
-const CONFIG_FILE_VERSION = 1
+const CONFIG_FILE_VERSION = "1.0"
 
 const pkg = JSON.parse(
   fs.readFileSync(


### PR DESCRIPTION
This adds `fileVersion` and `buildDate` to `metadata.json`. 
We're not tracking how `fileVersion` changes over time, but maybe there's a simple way to do it (for now its just a constant on `scripts/build_lint.js`.

Additionally, there's no types nor tests in this repo. 
So I think all stuff related to guarantees should be addressed in the future with a more thorough refactor of this project.
For example, in the project we validate `Fields` and `Presets` with `@mapeo/schema`. We could do the same with the metadata maybe but with some caveats (since `importDate` shouldn't exist before importing the config into an actual project...)