### PR TITLE
fix: throw on missing icon

### DIFF
--- a/scripts/check_icons.js
+++ b/scripts/check_icons.js
@@ -21,7 +21,7 @@ export default function checkIcons (presets, iconDir) {
     }
   })
   if (undefinedIcons.length) {
-    console.warn('Warning: No icon defined:\n- ' + undefinedIcons.join('\n- ') + '\n')
+    throw new Error('No icon defined:\n- ' + undefinedIcons.join('\n- ') + '\n')
   }
   if (missing.length) {
     throw new Error('Missing icons:\n- ' + missing.join('\n- ') + '\n')


### PR DESCRIPTION
Since we fail **HARD** when importing a categories file that has a preset without an icon in comapeo-core ([see](https://github.com/digidem/comapeo-core/blob/main/src/config-import.js#L204)) we should also maintain this logic on the settings builder so that we don't trip users (because we also don't actually show config-import warnings on the CoMapeo UI).
This is a possible solution, but we can also fix this issue on comapeo-core, by just skipping the invalid preset (which I don't think is a good solution because is also not transparent to users until we start showing this config-import warnings)